### PR TITLE
Add CSS Handles to CostumerInfo's component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- CSS Handles for CostumerInfo component
+- CSS Handles for CustomerInfo component
 
 ## [1.0.2] - 2019-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Changed
-
-- CostumerInfo function structure
-
 ### Added
 
 - CSS Handles for CostumerInfo component
-
 
 ## [1.0.2] - 2019-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- CostumerInfo function structure
+
+### Added
+
+- CSS Handles for CostumerInfo component
+
+
 ## [1.0.2] - 2019-12-10
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -298,3 +298,15 @@ interface Props {
   numPackages: number;
 }
 ```
+
+## Customization
+
+In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
+
+| CSS Handles      |
+| ---------------- |
+| `costumerInfoListContainer`   |
+| `costumerInfoListName`   |
+| `costumerInfoListEmail`   |
+| `costumerInfoListDocument`   |
+| `costumerInfoListPhone`   |

--- a/docs/README.md
+++ b/docs/README.md
@@ -305,8 +305,8 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 
 | CSS Handles      |
 | ---------------- |
-| `costumerInfoListContainer`   |
-| `costumerInfoListName`   |
-| `costumerInfoListEmail`   |
-| `costumerInfoListDocument`   |
-| `costumerInfoListPhone`   |
+| `customerInfoListContainer`   |
+| `customerInfoListName`   |
+| `customerInfoListEmail`   |
+| `customerInfoListDocument`   |
+| `customerInfoListPhone`   |

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,8 @@
     "vtex.shipping-estimate-translator": "2.x",
     "vtex.address-form": "4.x",
     "vtex.profile-form": "3.x",
-    "vtex.my-account-commons": "1.x"
+    "vtex.my-account-commons": "1.x",
+    "vtex.css-handles": "0.x"
   },
   "registries": [
     "smartcheckout"

--- a/react/CustomerInfo.tsx
+++ b/react/CustomerInfo.tsx
@@ -2,6 +2,10 @@ import React, { FunctionComponent } from 'react'
 import { InjectedIntlProps, injectIntl } from 'react-intl'
 import { ProfileRules, ProfileSummary } from 'vtex.profile-form'
 
+import { useCssHandles } from 'vtex.css-handles'
+
+const CSS_HANDLES = ['costumerInfoListContainer', 'costumerInfoListName', 'costumerInfoListEmail', 'costumerInfoListDocument', 'costumerInfoListPhone']
+
 interface Props {
   profile: ClientProfile
 }
@@ -9,27 +13,30 @@ interface Props {
 const CustomerInfo: FunctionComponent<Props & InjectedIntlProps> = ({
   profile,
   intl,
-}) => (
-  <div className="flex flex-column c-on-base">
-    <ProfileRules country={intl.locale} shouldUseIOFetching>
-      <ProfileSummary profile={profile}>
-        {({ personalData }: any) => (
-          <ul className="list pl0">
-            <li className="pv2">
-              {`${personalData.firstName.value} ${personalData.lastName.value}`}
-            </li>
-            <li className="pv2 c-muted-2">{personalData.email.value}</li>
-            {personalData.document && (
-              <li className="pv2 c-muted-2">{personalData.document.value}</li>
-            )}
-            {profile.phone && (
-              <li className="pv2 c-muted-2">{profile.phone}</li>
-            )}
-          </ul>
-        )}
-      </ProfileSummary>
-    </ProfileRules>
-  </div>
-)
+}) => {
+  const handles = useCssHandles(CSS_HANDLES)
+  return (
+    <div className="flex flex-column c-on-base">
+      <ProfileRules country={intl.locale} shouldUseIOFetching>
+        <ProfileSummary profile={profile}>
+          {({ personalData }: any) => (
+            <ul className={`${handles.costumerInfoListContainer} list pl0`}>
+              <li className={`${handles.costumerInfoListName} pv2`}>
+                {`${personalData.firstName.value} ${personalData.lastName.value}`}
+              </li>
+              <li className={`${handles.costumerInfoListEmail} pv2 c-muted-2`}>{personalData.email.value}</li>
+              {personalData.document && (
+                <li className={`${handles.costumerInfoListDocument} pv2 c-muted-2`}>{personalData.document.value}</li>
+              )}
+              {profile.phone && (
+                <li className={`${handles.costumerInfoListPhone} pv2 c-muted-2`}>{profile.phone}</li>
+              )}
+            </ul>
+          )}
+        </ProfileSummary>
+      </ProfileRules>
+    </div>
+  )
+}
 
 export default injectIntl(CustomerInfo)

--- a/react/CustomerInfo.tsx
+++ b/react/CustomerInfo.tsx
@@ -1,10 +1,15 @@
 import React, { FunctionComponent } from 'react'
 import { InjectedIntlProps, injectIntl } from 'react-intl'
 import { ProfileRules, ProfileSummary } from 'vtex.profile-form'
-
 import { useCssHandles } from 'vtex.css-handles'
 
-const CSS_HANDLES = ['costumerInfoListContainer', 'costumerInfoListName', 'costumerInfoListEmail', 'costumerInfoListDocument', 'costumerInfoListPhone']
+const CSS_HANDLES = [
+  'costumerInfoListContainer',
+  'costumerInfoListName',
+  'costumerInfoListEmail',
+  'costumerInfoListDocument',
+  'costumerInfoListPhone'
+]
 
 interface Props {
   profile: ClientProfile
@@ -22,14 +27,26 @@ const CustomerInfo: FunctionComponent<Props & InjectedIntlProps> = ({
           {({ personalData }: any) => (
             <ul className={`${handles.costumerInfoListContainer} list pl0`}>
               <li className={`${handles.costumerInfoListName} pv2`}>
-                {`${personalData.firstName.value} ${personalData.lastName.value}`}
+                {`${personalData.firstName.value} ${
+                  personalData.lastName.value
+                }`}
               </li>
-              <li className={`${handles.costumerInfoListEmail} pv2 c-muted-2`}>{personalData.email.value}</li>
+              <li className={`${handles.costumerInfoListEmail} pv2 c-muted-2`}>
+                {personalData.email.value}
+              </li>
               {personalData.document && (
-                <li className={`${handles.costumerInfoListDocument} pv2 c-muted-2`}>{personalData.document.value}</li>
+                <li
+                  className={`${
+                    handles.costumerInfoListDocument
+                  } pv2 c-muted-2`}>
+                  {personalData.document.value}
+                </li>
               )}
               {profile.phone && (
-                <li className={`${handles.costumerInfoListPhone} pv2 c-muted-2`}>{profile.phone}</li>
+                <li
+                  className={`${handles.costumerInfoListPhone} pv2 c-muted-2`}>
+                  {profile.phone}
+                </li>
               )}
             </ul>
           )}

--- a/react/CustomerInfo.tsx
+++ b/react/CustomerInfo.tsx
@@ -4,12 +4,12 @@ import { ProfileRules, ProfileSummary } from 'vtex.profile-form'
 import { useCssHandles } from 'vtex.css-handles'
 
 const CSS_HANDLES = [
-  'costumerInfoListContainer',
-  'costumerInfoListName',
-  'costumerInfoListEmail',
-  'costumerInfoListDocument',
-  'costumerInfoListPhone'
-]
+  'customerInfoListContainer',
+  'customerInfoListName',
+  'customerInfoListEmail',
+  'customerInfoListDocument',
+  'customerInfoListPhone'
+] as const
 
 interface Props {
   profile: ClientProfile
@@ -25,26 +25,26 @@ const CustomerInfo: FunctionComponent<Props & InjectedIntlProps> = ({
       <ProfileRules country={intl.locale} shouldUseIOFetching>
         <ProfileSummary profile={profile}>
           {({ personalData }: any) => (
-            <ul className={`${handles.costumerInfoListContainer} list pl0`}>
-              <li className={`${handles.costumerInfoListName} pv2`}>
+            <ul className={`${handles.customerInfoListContainer} list pl0`}>
+              <li className={`${handles.customerInfoListName} pv2`}>
                 {`${personalData.firstName.value} ${
                   personalData.lastName.value
                 }`}
               </li>
-              <li className={`${handles.costumerInfoListEmail} pv2 c-muted-2`}>
+              <li className={`${handles.customerInfoListEmail} pv2 c-muted-2`}>
                 {personalData.email.value}
               </li>
               {personalData.document && (
                 <li
                   className={`${
-                    handles.costumerInfoListDocument
+                    handles.customerInfoListDocument
                   } pv2 c-muted-2`}>
                   {personalData.document.value}
                 </li>
               )}
               {profile.phone && (
                 <li
-                  className={`${handles.costumerInfoListPhone} pv2 c-muted-2`}>
+                  className={`${handles.customerInfoListPhone} pv2 c-muted-2`}>
                   {profile.phone}
                 </li>
               )}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add CSS Handles for the order-details component.

#### What problem is this solving?

Adds CSS classes so that you have greater flexibility in using items rendered by the order-details component.

### How should this be manually tested?
- Enter this link: https://orderplaced--tackoftheday.myvtex.com/checkout/orderPlaced/?og=1018171103781
- Inspect the element for the order-details component information;
- You will see that the new CSS Handles have been added.

### Screenshots or example usage
https://cl.ly/9022af914444

Types of changes
- [ ] - Bug fix (a non-breaking change which fixes an issue)
- [X] - New feature (a non-breaking change which adds functionality)
- [ ] - Breaking change (fix or feature that would cause existing functionality to change)
- [ ] - Requires change to documentation, which has been updated accordingly.