### PR TITLE
Added CSS handles to payment method & address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Added
 
-- Added CSS Handles `paymentType` & `paymentValue` on PaymentMethod
+- Added CSS Handles `paymentGroup` & `paymentValue` on PaymentMethod
 - Added CSS Handle `addressContainer` on Address
 
 ## [1.1.1] - 2020-11-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Added
+
+- Added CSS Handles `paymentType` & `paymentValue` on PaymentMethod
+- Added CSS Handle `addressContainer` on Address
+
 ## [1.1.1] - 2020-11-16
 ### Fixed
 - Redirect to login when trying to print bank invoice while not logged-in.

--- a/docs/README.md
+++ b/docs/README.md
@@ -313,6 +313,9 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `customerInfoListEmail`   |
 | `customerInfoListDocument`   |
 | `customerInfoListPhone`   |
+| `paymentType`   |
+| `paymentValue`   |
+| `addressContainer`   |
 
 ## Contributors ✨
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -313,7 +313,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `customerInfoListEmail`   |
 | `customerInfoListDocument`   |
 | `customerInfoListPhone`   |
-| `paymentType`   |
+| `paymentGroup`   |
 | `paymentValue`   |
 | `addressContainer`   |
 

--- a/react/Address.tsx
+++ b/react/Address.tsx
@@ -1,14 +1,21 @@
 import React, { FunctionComponent } from 'react'
 import { AddressRules, AddressSummary } from 'vtex.address-form'
+import { useCssHandles } from 'vtex.css-handles'
 
 interface Props {
   address: Address
   pickup?: Parcel
 }
 
+const CSS_HANDLES = [
+  'addressContainer'
+] as const
+
 const Address: FunctionComponent<Props> = ({ address, pickup }) => {
+
+  const handles = useCssHandles(CSS_HANDLES)
   return (
-    <div className="c-muted-1 lh-copy" data-testid="address-component">
+    <div className={`${handles.addressContainer} c-muted-1 lh-copy`} data-testid="address-component">
       {pickup && (
         <p className="c-on-base lh-copy">{pickup.pickupFriendlyName}</p>
       )}

--- a/react/Address.tsx
+++ b/react/Address.tsx
@@ -12,8 +12,8 @@ const CSS_HANDLES = [
 ] as const
 
 const Address: FunctionComponent<Props> = ({ address, pickup }) => {
-
   const handles = useCssHandles(CSS_HANDLES)
+  
   return (
     <div className={`${handles.addressContainer} c-muted-1 lh-copy`} data-testid="address-component">
       {pickup && (

--- a/react/PaymentMethod.tsx
+++ b/react/PaymentMethod.tsx
@@ -27,7 +27,7 @@ interface Props {
 }
 
 const CSS_HANDLES = [
-  'paymentType',
+  'paymentGroup',
   'paymentValue'
 ] as const
 

--- a/react/PaymentMethod.tsx
+++ b/react/PaymentMethod.tsx
@@ -61,7 +61,7 @@ const PaymentMethod: FunctionComponent<Props & InjectedIntlProps> = ({
   return (
     <article className="flex justify-between">
       <div className="t-body lh-solid">
-        <p className={`${handles.paymentType} c-on-base`}>{paymentGroupSwitch(payment, intl)}</p>
+        <p className={`${handles.paymentGroup} c-on-base`}>{paymentGroupSwitch(payment, intl)}</p>
         {hasLastDigits && (
           <p className="c-muted-1 mb3">
             {intl.formatMessage(messages.lastDigits, {

--- a/react/PaymentMethod.tsx
+++ b/react/PaymentMethod.tsx
@@ -7,6 +7,7 @@ import ButtonLink from './ButtonLink'
 import Price from './FormattedPrice'
 import InfoIcon from './icons/Info'
 import { parseBankInvoiceUrl } from './utils'
+import { useCssHandles } from 'vtex.css-handles'
 
 const messages = defineMessages({
   creditcard: { id: 'store/payments.creditcard', defaultMessage: '' },
@@ -24,6 +25,11 @@ interface Props {
   transactionId: string
   currency: string
 }
+
+const CSS_HANDLES = [
+  'paymentType',
+  'paymentValue'
+] as const
 
 const paymentGroupSwitch = (payment: Payment, intl: ReactIntl.InjectedIntl) => {
   switch (payment.group) {
@@ -50,11 +56,12 @@ const PaymentMethod: FunctionComponent<Props & InjectedIntlProps> = ({
   const [isOpen, setIsOpen] = useState(false)
   const hasLastDigits = !!payment.lastDigits
   const isBankInvoice = payment.group === 'bankInvoice'
+  const handles = useCssHandles(CSS_HANDLES)
 
   return (
     <article className="flex justify-between">
       <div className="t-body lh-solid">
-        <p className="c-on-base">{paymentGroupSwitch(payment, intl)}</p>
+        <p className={`${handles.paymentType} c-on-base`}>{paymentGroupSwitch(payment, intl)}</p>
         {hasLastDigits && (
           <p className="c-muted-1 mb3">
             {intl.formatMessage(messages.lastDigits, {
@@ -63,7 +70,7 @@ const PaymentMethod: FunctionComponent<Props & InjectedIntlProps> = ({
           </p>
         )}
         <div className="flex items-center">
-          <p className="c-muted-1 mv0">
+          <p className={`${handles.paymentValue} c-muted-1 mv0`}>
             <Price value={payment.value} currency={currency} />
             {` ${intl.formatMessage(messages.installments, {
               installments: payment.installments,

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@vtex/tsconfig",
   "compilerOptions": {
+    "jsx": "react",
     "noEmitOnError": false,
     "lib": ["dom"],
     "module": "esnext",

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@vtex/tsconfig",
   "compilerOptions": {
-    "jsx": "react",
     "noEmitOnError": false,
     "lib": ["dom"],
     "module": "esnext",


### PR DESCRIPTION
#### What does this PR do? \*

It simply adds some CSS handles on PaymentMethod and Address components in order to style those blocks

#### How to test it? \*

Link this updated version on workspace that has order-placed default implementation and inspect element to check for the new CSS handles

#### Related to / Depends on \*

<!--- Optional -->
![image](https://user-images.githubusercontent.com/71461884/110393321-00ec1b80-8073-11eb-8d6c-05e035205023.png)
![image](https://user-images.githubusercontent.com/71461884/110393350-106b6480-8073-11eb-9304-ce21a38f0001.png)


