### PR TITLE
Add CSS Handlers to OrderOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Added
+
+- Added CSS Handles `cancellationButtonWrapper`, `myOrdersButtonWrapper`, `printReceiptButtonWrapper`, 
+`updateOrderButtonWrapper`, `printReceiptButton`, `updateButton`, `myOrdersButton`, `takeAwayCancelButton` & 
+`cancelButton` on OrderOptions
+
 ## [1.2.0] - 2021-03-10
 
 ## Added

--- a/react/ButtonLink.tsx
+++ b/react/ButtonLink.tsx
@@ -9,6 +9,7 @@ interface Props {
   openNewWindow?: boolean
   variation: string
   children: ReactChild
+  className?: string
 }
 
 const ButtonLink: FunctionComponent<Props> = ({
@@ -17,8 +18,9 @@ const ButtonLink: FunctionComponent<Props> = ({
   fullWidth,
   variation,
   children,
+  className
 }) => (
-  <Link to={to} data-testid="button-link">
+  <Link className={className} to={to} data-testid="button-link">
     {icon ? (
       <ButtonWithIcon icon={icon} variation={variation} block={fullWidth}>
         {children}

--- a/react/OrderOptions.tsx
+++ b/react/OrderOptions.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react'
 import { InjectedIntlProps, injectIntl, defineMessages } from 'react-intl'
+import { useCssHandles } from 'vtex.css-handles'
 
 import ButtonLink from './ButtonLink'
 
@@ -20,6 +21,18 @@ const messages = defineMessages({
   cancelButton: { id: 'store/order.header.cancel.button', defaultMessage: '' },
 })
 
+const CSS_HANDLES = [
+  'cancellationButtonWrapper',
+  'myOrdersButtonWrapper',
+  'printReceiptButtonWrapper',
+  'updateOrderButtonWrapper',
+  'printReceiptButton',
+  'updateButton',
+  'myOrdersButton',
+  'takeAwayCancelButton',
+  'cancelButton',
+] as const
+
 interface Props {
   allowCancellation: boolean
   takeaway?: boolean
@@ -35,49 +48,75 @@ const OrderOptions: FunctionComponent<Props & InjectedIntlProps> = ({
   className = '',
   fullWidth,
   orderId,
-}) => (
-  <div className={`${className} flex flex-wrap justify-center flex-nowrap-m`}>
-    <div className="mr5-ns mb5-s mb0-m w-100 w-auto-m">
+}) => {
+  const handles = useCssHandles(CSS_HANDLES)
+
+  return (
+    <div className={`${className} flex flex-wrap justify-center flex-nowrap-m`}>
       {takeaway ? (
-        <ButtonLink variation="secondary" fullWidth={fullWidth} to="">
-          {intl.formatMessage(messages.printReceiptButton)}
-        </ButtonLink>
+        <div
+          className={`${
+            handles.printReceiptButtonWrapper
+          } mr5-ns mb5-s mb0-m w-100 w-auto-m`}>
+          <ButtonLink
+            className={handles.printReceiptButton}
+            variation="secondary"
+            fullWidth={fullWidth}
+            to="">
+            {intl.formatMessage(messages.printReceiptButton)}
+          </ButtonLink>
+        </div>
       ) : (
-        <ButtonLink
-          variation="secondary"
-          fullWidth={fullWidth}
-          to={`/account#/orders/${orderId}/edit`}>
-          {intl.formatMessage(messages.updateButton)}
-        </ButtonLink>
+        <div
+          className={`${
+            handles.updateOrderButtonWrapper
+          } mr5-ns mb5-s mb0-m w-100 w-auto-m`}>
+          <ButtonLink
+            className={handles.updateButton}
+            variation="secondary"
+            fullWidth={fullWidth}
+            to={`/account#/orders/${orderId}/edit`}>
+            {intl.formatMessage(messages.updateButton)}
+          </ButtonLink>
+        </div>
+      )}
+      {!takeaway && (
+        <div
+          className={`${
+            handles.myOrdersButtonWrapper
+          } mr5-ns mb5-s mb0-m w-100 w-auto-m`}>
+          <ButtonLink
+            className={handles.myOrdersButton}
+            variation="secondary"
+            fullWidth={fullWidth}
+            to="/account#/orders/">
+            {intl.formatMessage(messages.myOrdersButton)}
+          </ButtonLink>
+        </div>
+      )}
+      {allowCancellation && (
+        <div className={`${handles.cancellationButtonWrapper} w-100 w-auto-m`}>
+          {takeaway ? (
+            <ButtonLink
+              className={handles.takeAwayCancelButton}
+              variation="danger-tertiary"
+              fullWidth={fullWidth}
+              to="">
+              {intl.formatMessage(messages.takeAwayCancelButton)}
+            </ButtonLink>
+          ) : (
+            <ButtonLink
+              className={handles.cancelButton}
+              variation="danger-tertiary"
+              fullWidth={fullWidth}
+              to={`/account#/orders/${orderId}/cancel`}>
+              {intl.formatMessage(messages.cancelButton)}
+            </ButtonLink>
+          )}
+        </div>
       )}
     </div>
-    {!takeaway && (
-      <div className="mr5-ns mb5-s mb0-m w-100 w-auto-m">
-        <ButtonLink
-          variation="secondary"
-          fullWidth={fullWidth}
-          to="/account#/orders/">
-          {intl.formatMessage(messages.myOrdersButton)}
-        </ButtonLink>
-      </div>
-    )}
-    {allowCancellation && (
-      <div className="w-100 w-auto-m">
-        {takeaway ? (
-          <ButtonLink variation="danger-tertiary" fullWidth={fullWidth} to="">
-            {intl.formatMessage(messages.takeAwayCancelButton)}
-          </ButtonLink>
-        ) : (
-          <ButtonLink
-            variation="danger-tertiary"
-            fullWidth={fullWidth}
-            to={`/account#/orders/${orderId}/cancel`}>
-            {intl.formatMessage(messages.cancelButton)}
-          </ButtonLink>
-        )}
-      </div>
-    )}
-  </div>
-)
+  )
+}
 
 export default injectIntl(OrderOptions)


### PR DESCRIPTION
#### What does this PR do? \*
Add CSS Handlers to OrderOptions for allowing modifications on these buttons:

![image](https://user-images.githubusercontent.com/17601387/112346086-61e73680-8ca4-11eb-9782-8c83c0064301.png)

#### How to test it? \*
1. Accessing orderPlaced page
2. Modifying styles 
  
