### PR TITLE
Fix/csshandle payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- CSS Handle for type of payment on PaymentMethod
+
 ## [1.3.0] - 2021-03-25
 ### Added
 - CSS Handles `updateOrderButton`, `myOrdersButton`, and `cancelOrderButton` on `OrderOptions`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- CSS Handle for type of payment on PaymentMethod.
 - Translation for gift card.
 
 ## [1.3.0] - 2021-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- CSS Handle for type of payment on PaymentMethod
+- CSS Handle for type of payment on PaymentMethod.
+- Translation for gift card.
 
 ## [1.3.0] - 2021-03-25
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -314,7 +314,6 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `customerInfoListDocument`   |
 | `customerInfoListPhone`   |
 | `paymentGroup`   |
-| `paymentGroup--${paymentGroup}`   |
 | `paymentValue`   |
 | `addressContainer`   |
 | `updateOrderButton` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -314,6 +314,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `customerInfoListDocument`   |
 | `customerInfoListPhone`   |
 | `paymentGroup`   |
+| `paymentGroup--${paymentGroup}`   |
 | `paymentValue`   |
 | `addressContainer`   |
 | `updateOrderButton` |

--- a/messages/en.json
+++ b/messages/en.json
@@ -28,6 +28,7 @@
   "store/payments.creditcard": "Credit card",
   "store/payments.creditcard.lastDigits": "Last digits: {lastDigits}",
   "store/payments.debitcard": "Debit card",
+  "store/payments.giftCard": "Gift card",
   "store/payments.id": "Payment ID: {id}",
   "store/payments.installments": "({installments}x)",
   "store/payments.transaction.id": "Transaction ID: {id}",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -28,6 +28,7 @@
   "store/payments.creditcard": "Cartão de crédito",
   "store/payments.creditcard.lastDigits": "Final {lastDigits}",
   "store/payments.debitcard": "Cartão de débito",
+  "store/payments.giftCard": "Vale presente",
   "store/payments.id": "ID do pagamento: {id}",
   "store/payments.installments": "{installments, plural, one {à vista} other { (#x)}}",
   "store/payments.transaction.id": "ID da transação: {id}",

--- a/react/PaymentMethod.tsx
+++ b/react/PaymentMethod.tsx
@@ -16,6 +16,7 @@ const messages = defineMessages({
     id: 'store/payments.creditcard.lastDigits',
     defaultMessage: '',
   },
+  giftCard: { id: 'store/payments.giftCard', defaultMessage: '' },
   installments: { id: 'store/payments.installments', defaultMessage: '' },
   print: { id: 'store/payments.bankinvoice.print', defaultMessage: '' },
 })
@@ -41,6 +42,8 @@ const paymentGroupSwitch = (payment: Payment, intl: ReactIntl.InjectedIntl) => {
       return payment.paymentSystemName
     case 'debitCard':
       return intl.formatMessage(messages.debitcard)
+    case 'giftCard':
+      return intl.formatMessage(messages.giftCard)
     default:
       return payment.paymentSystemName
   }

--- a/react/PaymentMethod.tsx
+++ b/react/PaymentMethod.tsx
@@ -61,7 +61,7 @@ const PaymentMethod: FunctionComponent<Props & InjectedIntlProps> = ({
   return (
     <article className="flex justify-between">
       <div className="t-body lh-solid">
-        <p className={`${handles.paymentGroup} c-on-base`}>{paymentGroupSwitch(payment, intl)}</p>
+        <p className={`${handles.paymentGroup} ${handles.paymentGroup}--${payment.group} c-on-base`}>{paymentGroupSwitch(payment, intl)}</p>
         {hasLastDigits && (
           <p className="c-muted-1 mb3">
             {intl.formatMessage(messages.lastDigits, {

--- a/react/PaymentMethod.tsx
+++ b/react/PaymentMethod.tsx
@@ -64,7 +64,9 @@ const PaymentMethod: FunctionComponent<Props & InjectedIntlProps> = ({
   return (
     <article className="flex justify-between">
       <div className="t-body lh-solid">
-        <p className={`${handles.paymentGroup} ${handles.paymentGroup}--${payment.group} c-on-base`}>{paymentGroupSwitch(payment, intl)}</p>
+        <p className={`${handles.paymentGroup} c-on-base`}>
+          {paymentGroupSwitch(payment, intl)}
+        </p>
         {hasLastDigits && (
           <p className="c-muted-1 mb3">
             {intl.formatMessage(messages.lastDigits, {


### PR DESCRIPTION
#### What does this PR do? \*

It includes the payment type in the class of its div in the orderplaced page. These classes can be: `creditCard`, `bankInvoice`, `promissory`, `debitCard`, `giftCard`, etc.
It mostly fixes the problem related in this [idea](https://ideas.vtex.com/ideas/VTEX-I-547), making us and our partners fix this part using CSS. Also, if the user may can add flags for each payment type.

#### How to test it? \*

https://vysk--worldwidegolf.myvtex.com/checkout/orderPlaced/?og=1124422276828

![](https://i.ibb.co/C9sBZph/orderplaced-PR.jpg)
#### Describe alternatives you've considered, if any. \*

I opened the idea, but it seems to be deeply coded in your core. The easier and quicker way is giving the possibility of at least change using css

