### PR TITLE
Fix message for promissory note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Message for promissory note and English and Romanian translations.
+
 ## [1.8.0] - 2022-01-31
 
 ### Added

--- a/messages/en.json
+++ b/messages/en.json
@@ -26,6 +26,7 @@
   "store/order.totals.total": "Total",
   "store/payments.bankinvoice.print": "Open {paymentSystemName}",
   "store/payments.creditcard": "Credit card",
+  "store/payments.promissory": "Promissory note",
   "store/payments.creditcard.lastDigits": "Last digits: {lastDigits}",
   "store/payments.debitcard": "Debit card",
   "store/payments.giftCard": "Gift card",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -26,6 +26,7 @@
   "store/order.totals.total": "Total",
   "store/payments.bankinvoice.print": "Deschis {paymentSystemName}",
   "store/payments.creditcard": "Card credit",
+  "store/payments.promissory": "Plata ramburs",
   "store/payments.creditcard.lastDigits": "Ultimele caractere: {lastDigits}",
   "store/payments.debitcard": "Card debit",
   "store/payments.giftCard": "Card cadou",

--- a/react/PaymentMethod.tsx
+++ b/react/PaymentMethod.tsx
@@ -11,6 +11,7 @@ import { useCssHandles } from 'vtex.css-handles'
 
 const messages = defineMessages({
   creditcard: { id: 'store/payments.creditcard', defaultMessage: '' },
+  promissory: { id: 'store/payments.promissory', defaultMessage: '' },
   debitcard: { id: 'store/payments.debitcard', defaultMessage: '' },
   lastDigits: {
     id: 'store/payments.creditcard.lastDigits',
@@ -39,7 +40,7 @@ const paymentGroupSwitch = (payment: Payment, intl: ReactIntl.InjectedIntl) => {
     case 'bankInvoice':
       return payment.paymentSystemName
     case 'promissory':
-      return payment.paymentSystemName
+      return intl.formatMessage(messages.promissory)
     case 'debitCard':
       return intl.formatMessage(messages.debitcard)
     case 'giftCard':


### PR DESCRIPTION
Fix message for promissory note payment method that is currently not showing, and English and Romanian translations. Related to [JIRA task LOC-8050](https://vtex-dev.atlassian.net/browse/LOC-8050).

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
