### PR TITLE
Feature/my account path order options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `myAccountPath` prop to `OrderDetails` component.
+
 ## [1.7.0] - 2021-10-29
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -151,6 +151,7 @@ interface Props {
   className?: string;
   fullWidth?: boolean;
   orderId?: string;
+  myAccountPath?: string;
 }
 ```
 

--- a/react/OrderOptions.tsx
+++ b/react/OrderOptions.tsx
@@ -27,6 +27,7 @@ interface Props {
   className?: string
   fullWidth?: boolean
   orderId?: string
+  myAccountPath?: string
 }
 
 const CSS_HANDLES = [
@@ -42,13 +43,16 @@ const OrderOptions: FunctionComponent<Props & InjectedIntlProps> = ({
   className = '',
   fullWidth,
   orderId,
+  myAccountPath = '/account',
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
 
   return (
     <div className={`${className} flex flex-wrap justify-center flex-nowrap-m`}>
       <div
-        className={`${handles.updateOrderButton} mr5-ns mb5-s mb0-m w-100 w-auto-m`}>
+        className={`${
+          handles.updateOrderButton
+        } mr5-ns mb5-s mb0-m w-100 w-auto-m`}>
         {takeaway ? (
           <ButtonLink variation="secondary" fullWidth={fullWidth} to="">
             {intl.formatMessage(messages.printReceiptButton)}
@@ -57,18 +61,20 @@ const OrderOptions: FunctionComponent<Props & InjectedIntlProps> = ({
           <ButtonLink
             variation="secondary"
             fullWidth={fullWidth}
-            to={`/account#/orders/${orderId}/edit`}>
+            to={`${myAccountPath}#/orders/${orderId}/edit`}>
             {intl.formatMessage(messages.updateButton)}
           </ButtonLink>
         )}
       </div>
       {!takeaway && (
         <div
-          className={`${handles.myOrdersButton} mr5-ns mb5-s mb0-m w-100 w-auto-m`}>
+          className={`${
+            handles.myOrdersButton
+          } mr5-ns mb5-s mb0-m w-100 w-auto-m`}>
           <ButtonLink
             variation="secondary"
             fullWidth={fullWidth}
-            to="/account#/orders/">
+            to={`${myAccountPath}#/orders/`}>
             {intl.formatMessage(messages.myOrdersButton)}
           </ButtonLink>
         </div>
@@ -83,7 +89,7 @@ const OrderOptions: FunctionComponent<Props & InjectedIntlProps> = ({
             <ButtonLink
               variation="danger-tertiary"
               fullWidth={fullWidth}
-              to={`/account#/orders/${orderId}/cancel`}>
+              to={`${myAccountPath}#/orders/${orderId}/cancel`}>
               {intl.formatMessage(messages.cancelButton)}
             </ButtonLink>
           )}


### PR DESCRIPTION
#### What does this PR do?

Add a new prop `myAccountPath` to `OrderOptions` component. This should enable developers to customize the links that are attached to each option displayed by the component.

![Screen Shot 2022-01-25 at 14 01 40](https://user-images.githubusercontent.com/27777263/151023655-ae5d4fad-9283-49ab-b0d2-b5f0a45b49ee.png)

#### How to test it?

1. Go to [this workspace](https://victormiranda--storeframework.myvtex.com/) and buy something;
2. After the checkout you'll be taken to this OrderPlaced page:

![Screen Shot 2022-01-25 at 14 05 58](https://user-images.githubusercontent.com/27777263/151024347-d3af3503-75f6-4852-8b54-f75bd5522fbd.png)

3. Now click any of the options and notice that you'll be redirected to a path starting with `/api/io/account`. This was configured in the store's theme:

```json
"op-order-options#desktop": {
  "props": {
    "myAccountPath": "/api/io/account"
  }
},
```

#### Describe alternatives you've considered if any. \*

I've considered adding a prop for each of the options, but I went with a single prop because it's a smaller change in the API and if new options are added in the future, no new props would need to be created.

#### Related to / Depends on \*

This should be released before https://github.com/vtex-apps/order-placed/pull/175.
