### PR TITLE
add cssHandle on payment installments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- add cssHandle on payment installments
+
 ## [1.9.0] - 2022-12-23
 
 ### Added

--- a/react/PaymentMethod.tsx
+++ b/react/PaymentMethod.tsx
@@ -30,7 +30,8 @@ interface Props {
 
 const CSS_HANDLES = [
   'paymentGroup',
-  'paymentValue'
+  'paymentValue',
+  'paymentInstallments'
 ] as const
 
 const paymentGroupSwitch = (payment: Payment, intl: ReactIntl.InjectedIntl) => {
@@ -78,9 +79,9 @@ const PaymentMethod: FunctionComponent<Props & InjectedIntlProps> = ({
         <div className="flex items-center">
           <p className={`${handles.paymentValue} c-muted-1 mv0`}>
             <Price value={payment.value} currency={currency} />
-            {` ${intl.formatMessage(messages.installments, {
+            <span className={`${handles.paymentInstallments}`}>{` ${intl.formatMessage(messages.installments, {
               installments: payment.installments,
-            })}`}
+            })}`}</span>
           </p>
           <div
             className="ml4"


### PR DESCRIPTION
#### What does this PR do? \*

add a css handle on payment installment

#### How to test it? \*

buy a product and on order placed page, installment info must have a span wrapping it.

`<p class="vtex-order-placed-2-x-paymentValue c-muted-1 mv0">$208.04<span class="vtex-order-placed-2-x-paymentInstallments"> (1x)</span></p>`

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
