### PR TITLE
✨ Add payment system name and payment origin on payment summary when paid with creditCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Payment system name and payment origin on payment summary when paid with creditCard
+
 ## [1.9.1] - 2023-02-16
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -234,6 +234,7 @@ interface Payment {
   id: string;
   paymentSystem: string;
   paymentSystemName: string;
+  paymentOrigin: string | null;
   value: number;
   lastDigits: string | null;
   group: string;

--- a/react/PaymentMethod.tsx
+++ b/react/PaymentMethod.tsx
@@ -59,6 +59,8 @@ const PaymentMethod: FunctionComponent<Props & InjectedIntlProps> = ({
 }) => {
   const { rootPath } = useRuntime()
   const [isOpen, setIsOpen] = useState(false)
+  const hasPaymentSystemName = payment.paymentSystemName
+  const hasPaymentOrigin = !!payment.paymentOrigin
   const hasLastDigits = !!payment.lastDigits
   const isBankInvoice = payment.group === 'bankInvoice'
   const handles = useCssHandles(CSS_HANDLES)
@@ -69,8 +71,16 @@ const PaymentMethod: FunctionComponent<Props & InjectedIntlProps> = ({
         <p className={`${handles.paymentGroup} c-on-base`}>
           {paymentGroupSwitch(payment, intl)}
         </p>
-        {hasLastDigits && (
+        {hasPaymentSystemName && (
           <p className="c-muted-1 mb3">
+            {payment.paymentSystemName}
+            {hasPaymentOrigin && (
+              <span>&nbsp;({payment.paymentOrigin})</span>
+            )}
+          </p>
+        )}
+        {hasLastDigits && (
+          <p className="c-muted-1 mt0 mb3">
             {intl.formatMessage(messages.lastDigits, {
               lastDigits: payment.lastDigits,
             })}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -128,6 +128,7 @@ interface Payment {
   id: string
   paymentSystem: string
   paymentSystemName: string
+  paymentOrigin: string | null
   value: number
   lastDigits: string | null
   group: string


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
ATTS

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Since the Payments team is implementing a native solution for Google Pay, we must inform that the payment was made with Google Pay. This info is available at the prop `paymentOrigin` that is going to be provided at the end point `/api/checkout/pub/orders/order-group/${orderGroup}`.

#### How should this be manually tested?
* Finish a purchase at [this store](https://krro--storecomponents.myvtex.com/checkout) with credit card

#### Screenshots or example usage
**_BEFORE_**
![order-placed](https://user-images.githubusercontent.com/4183629/225013334-5610876c-6944-472a-acfa-e69705639ba0.png)

**_AFTER_**
Order finished with credit card - displaying payment method name
![order-placed-paymentMethodName](https://user-images.githubusercontent.com/4183629/224826385-275508e9-d8b9-4ddb-a352-de290eda3daf.png)

Order finished with Google Pay - displaying payment method and wallet name
![order-placed-paymentOrigin](https://user-images.githubusercontent.com/4183629/224826389-dcc0ad5b-d7c8-4726-a18b-bc3afc45fc31.png)

#### Related to / Depends on
<!--- Optional -->
[✨ Add field paymentOrigin to Payment](https://github.com/vtex/order-placed-graphql/pull/30) - order-placed-graphql
[✨ Add field paymentOrigin to getOrderGroup graphql](https://github.com/vtex-apps/order-placed/pull/186) - order-placed
[Jira Task](https://vtex-dev.atlassian.net/browse/SETUP-347)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

